### PR TITLE
fix: use route path instead of route name for bufferRouteState

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ const flowProvider = new FlowProvider()
 provideFlowProvider(flowProvider)
 
 // register each page where you will use 
-flowProvider.registerPage('/', index)
-flowProvider.registerPage('/home', about)
-flowProvider.registerPage('/about', about)
+flowProvider.registerPage(index)
+flowProvider.registerPage(about)
 ```
 
 # Example

--- a/src/FlowProvider.ts
+++ b/src/FlowProvider.ts
@@ -78,7 +78,7 @@ export class FlowProvider {
   }
 
   public triggerCrossfade(crossfadeMode: boolean | 'TOP' | 'UNDER' | 'BOTTOM') {
-    this.bufferRouteState && (this.bufferRouteState.value = this.routerMap.get(this.routeTo.name!.toString()));
+    this.bufferRouteState && (this.bufferRouteState.value = this.routerMap.get(this.routeTo.path!.toString()));
     if (!!this.bufferRouteState?.value) {
       this.bufferTopZState && (this.bufferTopZState.value = crossfadeMode == 'TOP')
     }

--- a/src/FlowProvider.ts
+++ b/src/FlowProvider.ts
@@ -78,7 +78,7 @@ export class FlowProvider {
   }
 
   public triggerCrossfade(crossfadeMode: boolean | 'TOP' | 'UNDER' | 'BOTTOM') {
-    this.bufferRouteState && (this.bufferRouteState.value = this.routerMap.get(this.routeTo.path!.toString()));
+    this.bufferRouteState && (this.bufferRouteState.value = this.routerMap.get(this.routeTo.name!.toString()));
     if (!!this.bufferRouteState?.value) {
       this.bufferTopZState && (this.bufferTopZState.value = crossfadeMode == 'TOP')
     }

--- a/src/FlowProvider.ts
+++ b/src/FlowProvider.ts
@@ -45,8 +45,8 @@ export class FlowProvider {
     this.routerMap = new Map()
   }
 
-  registerPage(path: string, pageComponent: DefineComponent<{}, {}, any>) {
-    this.routerMap.set(path, pageComponent)
+  registerPage(pageComponent: DefineComponent<{}, {}, any>) {
+    this.routerMap.set(pageComponent.__name, pageComponent)
   }
 
   registerScrollInterface(api: { stop: () => void, resume: () => void, scrollToTop: () => void } | undefined) {


### PR DESCRIPTION
As the routerMap of the FlowProvider is using the path as key and not the name. The buffer when using crossfade was not working.